### PR TITLE
Avoiding of unsupported by AppleClang jthread and stop_token

### DIFF
--- a/include/ppqsort/parallel/cpp/mainloop_par.h
+++ b/include/ppqsort/parallel/cpp/mainloop_par.h
@@ -135,7 +135,7 @@ namespace ppqsort::impl {
              typename Compare = std::less<typename std::iterator_traits<RandomIt>::value_type>,
              bool Branchless = use_branchless<typename std::iterator_traits<RandomIt>::value_type, Compare>::value>
     void par_ppqsort(RandomIt begin, RandomIt end, Compare comp = Compare(),
-                     int threads = static_cast<int>(std::jthread::hardware_concurrency())) {
+                     int threads = static_cast<int>(std::thread::hardware_concurrency())) {
         if (begin == end)
             return;
         constexpr bool branchless = Force_branchless || Branchless;


### PR DESCRIPTION
Hi!

AppleClang does not support jthread and stop_token (as well as OpenMP) and therefore one can not build PPQSort with this compiler. This patch replaces `std::jthread` with `std::thread` and `std::stop_token` with `ThreadPool`-shared `to_stop_` variable. A bit stupid,  but seems it works :)

See C++20 features status by different compilers here: https://en.cppreference.com/w/cpp/compiler_support/20